### PR TITLE
Fix map generation

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -691,8 +691,3 @@ export class GameMap {
 }
 
 export const GAME_MAP: GameMap = new GameMap();
-GAME_MAP.clear();
-if (!GAME_MAP.loadFromStorage()) {
-    GAME_MAP.generate();
-}
-GAME_MAP.setDiscovered(0, 0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,12 @@
 // Simple bootstrap 
 //
 import { GAME } from "./Game";
+import { GAME_MAP } from "./Map";
+
+GAME_MAP.clear();
+if (!GAME_MAP.loadFromStorage()) {
+    GAME_MAP.generate();
+}
+GAME_MAP.setDiscovered(0, 0);
 
 GAME.startLoop();


### PR DESCRIPTION
The commit "Refactor into sensible class seperations" (315f3445) broke the initial map generation. When there is no map in the local storage, in `Map.ts` `GAME_MAP.generate()` gets called. I *think* because this is in the global namespace it is not guaranteed that the Game class is already instantiated. So I got
```
Uncaught TypeError: Cannot read properties of undefined (reading 'isHostingTheServer')
    at GameMap.setTile (Map.ts:530:22)
    at GameMap.generate (Map.ts:231:18)
    at eval (Map.ts:696:14)
    at ./src/Map.ts (bundle.js?v=35:139:1)
    at __webpack_require__ (bundle.js?v=35:1186:33)
    at fn (bundle.js?v=35:1386:21)
    at eval (HtmlUi.ts:1:1)
    at ./src/HtmlUi.ts (bundle.js?v=35:128:1)
    at __webpack_require__ (bundle.js?v=35:1186:33)
    at fn (bundle.js?v=35:1386:21)
    ```
    I moved this code to the bootstrap to make sure everything is already there. I am not sure though if all the lines should be moved there and if the `setDiscovered` might need to be moved inside the if.